### PR TITLE
use gunicorn to run django wsgi app

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/ubccr/coldfront#egg=coldfront
 git+https://github.com/knikolla/coldfront-plugin-openstack#egg=coldfront_plugin_openstack
 mysqlclient
+gunicorn

--- a/src/bin/run_coldfront.sh
+++ b/src/bin/run_coldfront.sh
@@ -11,4 +11,4 @@ sleep 10
 python -m django initial_setup
 python -m django register_openstack_attributes
 
-python -m django runserver 0.0.0.0:8080
+python -m gunicorn coldfront.config.wsgi -b 0.0.0.0:8080


### PR DESCRIPTION
Number of gunicorn workers can be set via `WEB_CONCURRENCY` environment variable which defaults to 1:

https://docs.gunicorn.org/en/stable/settings.html#worker-processeshttps://docs.gunicorn.org/en/stable/settings.html#worker-processes

closes #4