### PR TITLE
Switch repo urls to nerc-project/<repo>

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 git+https://github.com/ubccr/coldfront#egg=coldfront
-git+https://github.com/knikolla/coldfront-plugin-openstack#egg=coldfront_plugin_openstack
-git+https://github.com/knikolla/coldfront-plugin-keycloak-usersearch@0a5b0be1eff4c9d4565d1a25ba80dbca45624a87#egg=coldfront_plugin_keycloak_usersearch
+git+https://github.com/nerc-project/coldfront-plugin-openstack#egg=coldfront_plugin_openstack
+git+https://github.com/nerc-project/coldfront-plugin-keycloak@0a5b0be1eff4c9d4565d1a25ba80dbca45624a87#egg=coldfront_plugin_keycloak_usersearch
 mysqlclient
 psycopg2 >= 2.8, < 2.9
 mozilla-django-oidc


### PR DESCRIPTION
- Renamed coldfront-plugin-keycloak-usersearch to a more generic
coldfront-plugin-keycloak to prepare for possible code handling the
authentication as well rather than relying on the mokey
plugin.

Closes #17 