### PR TITLE
set DB variables for static-files init container

### DIFF
--- a/k8s/base/static-files/deployment.yaml
+++ b/k8s/base/static-files/deployment.yaml
@@ -15,6 +15,13 @@ spec:
         image: 'ghcr.io/nerc-project/coldfront-nerc:main'
         imagePullPolicy: Always
         command: ["/bin/sh", "-c", "STATIC_ROOT=/webroot/static /opt/venv/bin/django-admin.py collectstatic"]
+        env:
+          - name: DATABASE_HOST
+            value: ''
+          - name: DATABASE_USER
+            value: ''
+          - name: DATABASE_PASSWORD
+            value: ''
         volumeMounts:
         - name: coldfront-static-files
           mountPath: /webroot


### PR DESCRIPTION
Not really used by this container but the django-admin command isn't
happy without them being set due to our recent updates to
`local_settings.py` for DB settings.