### PR TITLE
Add NERC text customizations

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,6 +35,10 @@ services:
       KEYCLOAK_PASS: "nomoresecret"
       KEYCLOAK_REALM: "master"
       ADDITIONAL_USER_SEARCH_CLASSES: "coldfront_plugin_keycloak_usersearch.search.KeycloakUserSearch"
+      CENTER_NAME: "New England Research Cloud"
+      CENTER_HELP_URL: "https://nerc.mghpcc.org/user-guides/"
+      ACCOUNT_CREATION_TEXT: >
+        Any faculty, staff, student, or external collaborator must request an user account through the <a href="https://regapp.mss.mghpcc.org/" target="_blank">MGHPCC Shared Services (MGHPCC-SS) Account Portal</a>. For more information, please see the <a href="https://nerc.mghpcc.org/user-guides/" target="_blank">user guides</a>.
     ports:
       - "8080:8080"
 

--- a/k8s/overlays/prod/configmap.yaml
+++ b/k8s/overlays/prod/configmap.yaml
@@ -19,3 +19,7 @@ data:
   KEYCLOAK_URL: 'https://keycloak.mss.mghpcc.org'
   KEYCLOAK_REALM: 'mss'
   FORWARDED_ALLOW_IPS: '*'
+  CENTER_NAME: "New England Research Cloud"
+  CENTER_HELP_URL: "https://nerc.mghpcc.org/user-guides/"
+  ACCOUNT_CREATION_TEXT: >
+    Any faculty, staff, student, or external collaborator must request an user account through the <a href="https://regapp.mss.mghpcc.org/" target="_blank">MGHPCC Shared Services (MGHPCC-SS) Account Portal</a>. For more information, please see the <a href="https://nerc.mghpcc.org/user-guides/" target="_blank">user guides</a>.

--- a/src/local_settings.py
+++ b/src/local_settings.py
@@ -12,6 +12,10 @@ include(plugin_keycloak_usersearch.get_filename())
 
 ADDITIONAL_USER_SEARCH_CLASSES = ["coldfront_plugin_keycloak_usersearch.search.KeycloakUserSearch"]
 
+# ColdFront upstream ignores the env var even though it exposes the setting.
+# https://github.com/ubccr/coldfront/blob/c490acddd2853a39201ebc58d3ba0d2c1eb8f623/coldfront/config/core.py#L80
+ACCOUNT_CREATION_TEXT = os.getenv('ACCOUNT_CREATION_TEXT')
+
 if os.getenv('DEBUG', 'False') == 'True':
     SESSION_COOKIE_SECURE = False
     SESSION_COOKIE_SAMESITE = 'Lax'


### PR DESCRIPTION
- Updates the account creation text to point to Regapp.
- Updates center name and help url.
- Updates settings to read ACCOUNT_CREATION_TEXT from env var.