### PR TITLE
Update coldfront-plugin-openstack to include default network work

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/ubccr/coldfront@7dc4391c0cb54ec85ff82a0199ff0461454d5fb0#egg=coldfront
-git+https://github.com/nerc-project/coldfront-plugin-openstack@9c931e4e9d4898eab3631c29be161c17db648e13#egg=coldfront_plugin_openstack
+git+https://github.com/nerc-project/coldfront-plugin-openstack@ccaaca9783fd566b213335b8f71fd2511c0079ae#egg=coldfront_plugin_openstack
 git+https://github.com/nerc-project/coldfront-plugin-keycloak@0dd8e0ae65211d2f145abfd8d1402efe96562d29#egg=coldfront_plugin_keycloak_usersearch
 mysqlclient
 psycopg2 >= 2.8, < 2.9


### PR DESCRIPTION
Upgrade notes:
- Register attributes must be run again to pick up 2 new attributes on a resource.
- 'OpenStack Public Network ID' must be set on resource resource.
- 'OpenStack Default Network CIDR' may be set on the resource, but it defaults to 192.168.0.0/24

https://github.com/nerc-project/coldfront-plugin-openstack/commit/ccaaca9783fd566b213335b8f71fd2511c0079ae