### PR TITLE
add production db config

### DIFF
--- a/k8s/overlays/prod/ha-postgres.yaml
+++ b/k8s/overlays/prod/ha-postgres.yaml
@@ -27,8 +27,18 @@ spec:
   backups:
     pgbackrest:
       image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.35-0
+      configuration:
+      - secret:
+          name: pgo-s3-conf
+      # - secret:
+      #     name: pgo-pgbackrest-secrets
+      global:
+        # repo1-cipher-type: aes-256-cbc
+        # repo2-cipher-type: aes-256-cbc
+        repo2-path: /pgbackrest/postgres-operator/coldfront-postgres-ha/repo2
+        repo2-s3-uri-style: path
       manual:
-        repoName: repo1
+        repoName: repo2
         options:
          - --type=full
       repos:
@@ -43,6 +53,14 @@ spec:
             resources:
               requests:
                 storage: 5Gi
+      - name: repo2
+        schedules:
+          full: "0 1 * * *"
+          incremental: "0 */4 * * *"
+        s3:
+          bucket: "nerc-shift-1-backups"
+          endpoint: "holecs.rc.fas.harvard.edu"
+          region: "us-east-1"
   proxy:
     pgBouncer:
       image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-3

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -3,6 +3,8 @@ resources:
   - configmap.yaml
   - secrets/coldfront.yaml
   - secrets/coldfront-tls.yaml
+  - secrets/pgo-s3-conf.yaml
+  - secrets/pgo-pgbackrest-secrets.yaml
   - ha-postgres.yaml
   - ../../base
   - ingress.yaml

--- a/k8s/overlays/prod/secrets/pgo-pgbackrest-secrets.yaml
+++ b/k8s/overlays/prod/secrets/pgo-pgbackrest-secrets.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: pgo-pgbackrest-secrets
+spec:
+  target:
+    name: pgo-pgbackrest-secrets
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  dataFrom:
+    - key: pgbackrest/coldfront-postgres-ha/cipher

--- a/k8s/overlays/prod/secrets/pgo-s3-conf.yaml
+++ b/k8s/overlays/prod/secrets/pgo-s3-conf.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: pgo-s3-conf
+spec:
+  target:
+    name: pgo-s3-conf
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  dataFrom:
+    - key: accounts/holecs


### PR DESCRIPTION
- add offsite backup config via S3-compatible storage (ECS)
- ship manual/one-off backups (via postgrescluster annotation) to S3
- stage config for client-side encryption of backups via aes-256-cbc
  with passphrase (will require maintenance or rebuild to deploy properly)