### PR TITLE
set backup retentions to 30 days

### DIFF
--- a/k8s/overlays/prod/ha-postgres.yaml
+++ b/k8s/overlays/prod/ha-postgres.yaml
@@ -37,6 +37,8 @@ spec:
         # repo2-cipher-type: aes-256-cbc
         repo2-path: /pgbackrest/postgres-operator/coldfront-postgres-ha/repo2
         repo2-s3-uri-style: path
+        repo1-retention-full: "30"
+        repo2-retention-full: "30"
       manual:
         repoName: repo2
         options:


### PR DESCRIPTION
Our full backups are set to run nightly so this will clean up all but the last 30 days of backups (incremental backups get cleaned up based on which full backups they reference).