### PR TITLE
set CENTER_BASE_URL for allocation tasks

### DIFF
--- a/k8s/overlays/prod/configmap.yaml
+++ b/k8s/overlays/prod/configmap.yaml
@@ -21,6 +21,7 @@ data:
   FORWARDED_ALLOW_IPS: '*'
   REDIS_HOST: 'coldfront-redis'
   CENTER_NAME: "New England Research Cloud"
+  CENTER_BASE_URL: "https://coldfront.mss.mghpcc.org"
   CENTER_HELP_URL: "https://nerc.mghpcc.org/user-guides/"
   ACCOUNT_CREATION_TEXT: >
     Any faculty, staff, student, or external collaborator must request an user account through the <a href="https://regapp.mss.mghpcc.org/" target="_blank">MGHPCC Shared Services (MGHPCC-SS) Account Portal</a>. For more information, please see the <a href="https://nerc.mghpcc.org/user-guides/" target="_blank">user guides</a>.


### PR DESCRIPTION
This is used in various email templates
