### PR TITLE
update openstack plugin for quota and gpu usage auditing support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/ubccr/coldfront@2e60db247fd9a9b0d1299f1e98f1e4ef5f5c259b#egg=coldfront
-git+https://github.com/nerc-project/coldfront-plugin-openstack@c3b72695f093a047d038c3119764e0e2f7bed0fc#egg=coldfront_plugin_openstack
+git+https://github.com/nerc-project/coldfront-plugin-openstack@15a524fc960e7d00828af774a07ee49b7dd6066d#egg=coldfront_plugin_openstack
 git+https://github.com/nerc-project/coldfront-plugin-keycloak@0dd8e0ae65211d2f145abfd8d1402efe96562d29#egg=coldfront_plugin_keycloak_usersearch
 mysqlclient
 psycopg2 >= 2.8, < 2.9


### PR DESCRIPTION
Pulls in latest version of coldfront-plugin-openstack to pull in quota and gpu usage auditing support:

- https://github.com/nerc-project/coldfront-plugin-openstack/pull/56
- https://github.com/nerc-project/coldfront-plugin-openstack/pull/57