### PR TITLE
Update command register_cloud_attributes

### DIFF
--- a/src/bin/run_coldfront.sh
+++ b/src/bin/run_coldfront.sh
@@ -15,7 +15,7 @@ sleep 10
 if [[ "$INITIAL_SETUP" == "True" ]]
 then
   python -m django initial_setup
-  python -m django register_openstack_attributes
+  python -m django register_cloud_attributes
 fi
 
 if [[ "$LOAD_TEST_DATA" == "True" ]]


### PR DESCRIPTION
`register_openstack_attributes` was renamed to `register_cloud_attributes` with the introduction of OpenShift support.