### PR TITLE
Add externalsecret for NERC OpenShift

### DIFF
--- a/k8s/overlays/prod/secrets/coldfront.yaml
+++ b/k8s/overlays/prod/secrets/coldfront.yaml
@@ -26,6 +26,22 @@ spec:
     remoteRef:
       key: coldfront/nerc-openstack-app-creds
       property: OPENSTACK_NERC_APPLICATION_CREDENTIAL_SECRET
+  - secretKey: OPENSHIFT_NERC_USERNAME
+    remoteRef:
+      key: coldfront/nerc-openshift-acct-mgt-credentials
+      property: OPENSHIFT_NERC_USERNAME
+  - secretKey: OPENSHIFT_NERC_PASSWORD
+    remoteRef:
+      key: coldfront/nerc-openshift-acct-mgt-credentials
+      property: OPENSHIFT_NERC_PASSWORD
+  - secretKey: OPENSHIFT_NERC_EXPERIMENTAL_USERNAME
+    remoteRef:
+      key: coldfront/nerc-openshift-acct-mgt-credentials
+      property: OPENSHIFT_NERC_EXPERIMENTAL_USERNAME
+  - secretKey: OPENSHIFT_NERC_EXPERIMENTAL_PASSWORD
+    remoteRef:
+      key: coldfront/nerc-openshift-acct-mgt-credentials
+      property: OPENSHIFT_NERC_EXPERIMENTAL_PASSWORD
   - secretKey: KEYCLOAK_USER
     remoteRef:
       key: coldfront/keycloak-creds


### PR DESCRIPTION
The environment variable needs to match the name of the resource. Given that the resource type will be shown in parentheses, the name of OCP Prod will show up as NERC (OpenShift).

I've also added the same secret a second time for a possible NERC Experimental resource name, which we can later rename to just NERC without needing a restart or redeploy.

Closes #69 