### PR TITLE
add coldfront-staging overlay

### DIFF
--- a/k8s/overlays/staging/configmap.yaml
+++ b/k8s/overlays/staging/configmap.yaml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coldfront-configmap
+data:
+  DEBUG: "False"
+  DATABASE_ENGINE: 'django.db.backends.postgresql'
+  OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_ID: ""
+  OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_SECRET: ""
+  PLUGIN_AUTH_OIDC: "True"
+  PLUGIN_MOKEY: "True"
+  OIDC_RP_SIGN_ALGO: RS256
+  OIDC_RP_SCOPES: "openid email profile"
+  OIDC_OP_AUTHORIZATION_ENDPOINT: "https://keycloak.mss.mghpcc.org/auth/realms/mss/protocol/openid-connect/auth"
+  OIDC_OP_TOKEN_ENDPOINT: "https://keycloak.mss.mghpcc.org/auth/realms/mss/protocol/openid-connect/token"
+  OIDC_OP_USER_ENDPOINT: "https://keycloak.mss.mghpcc.org/auth/realms/mss/protocol/openid-connect/userinfo"
+  OIDC_OP_JWKS_ENDPOINT: "https://keycloak.mss.mghpcc.org/auth/realms/mss/protocol/openid-connect/certs"
+  OIDC_AUTHENTICATION_CALLBACK_URL: "https://coldfront-staging.mss.mghpcc.org/oidc/callback/"
+  KEYCLOAK_URL: 'https://keycloak.mss.mghpcc.org'
+  KEYCLOAK_REALM: 'mss'
+  FORWARDED_ALLOW_IPS: '*'
+  REDIS_HOST: 'coldfront-redis'
+  CENTER_NAME: "New England Research Cloud"
+  CENTER_BASE_URL: "https://coldfront-staging.mss.mghpcc.org"
+  CENTER_HELP_URL: "https://nerc.mghpcc.org/user-guides/"
+  CENTER_PROJECT_RENEWAL_HELP_URL: "https://nerc.mghpcc.org/user-guides/"
+  ACCOUNT_CREATION_TEXT: >
+    Any faculty, staff, student, or external collaborator must request an user account through the <a href="https://regapp.mss.mghpcc.org/" target="_blank">MGHPCC Shared Services (MGHPCC-SS) Account Portal</a>. For more information, please see the <a href="https://nerc.mghpcc.org/user-guides/" target="_blank">user guides</a>.
+  EMAIL_ENABLED: 'True'
+  EMAIL_USE_TLS: 'True'
+  EMAIL_HOST: 'email-smtp.us-east-1.amazonaws.com'
+  EMAIL_PORT: '587'
+  EMAIL_TICKET_SYSTEM_ADDRESS: 'help@nerc.mghpcc.org'
+  EMAIL_ADMIN_LIST: 'help@nerc.mghpcc.org'
+  EMAIL_SENDER: 'help@nerc.mghpcc.org'
+  EMAIL_DIRECTOR_EMAIL_ADDRESS: 'help@nerc.mghpcc.org'
+  EMAIL_PROJECT_REVIEW_CONTACT: 'help@nerc.mghpcc.org'
+  EMAIL_DEVELOPMENT_EMAIL_LIST: 'help@nerc.mghpcc.org'
+  EMAIL_SIGNATURE: |
+    New England Research Cloud (NERC)
+    https://nerc.mghpcc.org
+    https://nerc-project.github.io/nerc-docs
+    https://nerc.instatus.com

--- a/k8s/overlays/staging/ha-postgres.yaml
+++ b/k8s/overlays/staging/ha-postgres.yaml
@@ -1,0 +1,52 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: coldfront-postgres-ha
+spec:
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.4-1
+  postgresVersion: 13
+  instances:
+    - name: pgha1
+      replicas: 2
+      dataVolumeClaimSpec:
+        accessModes:
+        - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 5Gi
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  postgres-operator.crunchydata.com/cluster: coldfront-postgres-ha
+                  postgres-operator.crunchydata.com/instance-set: pgha1
+  backups:
+    pgbackrest:
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.35-0
+      repos:
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 5Gi
+  proxy:
+    pgBouncer:
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-3
+      replicas: 2
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  postgres-operator.crunchydata.com/cluster: coldfront-postgres-ha
+                  postgres-operator.crunchydata.com/role: pgbouncer

--- a/k8s/overlays/staging/ingress.yaml
+++ b/k8s/overlays/staging/ingress.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-buffering: "on"
+    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "256k"
+    nginx.ingress.kubernetes.io/proxy-max-temp-file-size: "1024m"
+  name: coldfront-ingress
+spec:
+  tls:
+    - hosts:
+      - coldfront-staging.mss.mghpcc.org
+      secretName: coldfront-tls  # pragma: allowlist secret
+  rules:
+    - host: coldfront-staging.mss.mghpcc.org
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: coldfront
+                port:
+                  number: 80
+
+          - path: /static
+            pathType: Prefix
+            backend:
+              service:
+                name: coldfront-static-files
+                port:
+                  number: 80

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -1,0 +1,10 @@
+namespace: coldfront-staging
+resources:
+  - configmap.yaml
+  - secrets/coldfront.yaml
+  - ha-postgres.yaml
+  - ../../base
+  - ingress.yaml
+patchesStrategicMerge:
+  - patches/coldfront-deployment.yaml
+  - patches/qcluster-deployment.yaml

--- a/k8s/overlays/staging/patches/coldfront-deployment.yaml
+++ b/k8s/overlays/staging/patches/coldfront-deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coldfront-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: coldfront
+        env:
+          - name: DATABASE_HOST
+            valueFrom:
+              secretKeyRef:
+                name: coldfront-postgres-ha-pguser-coldfront-postgres-ha
+                key: host
+          - name: DATABASE_PORT
+            valueFrom:
+              secretKeyRef:
+                name: coldfront-postgres-ha-pguser-coldfront-postgres-ha
+                key: port
+          - name: DATABASE_NAME
+            valueFrom:
+              secretKeyRef:
+                name: coldfront-postgres-ha-pguser-coldfront-postgres-ha
+                key: dbname
+          - name: DATABASE_USER
+            valueFrom:
+              secretKeyRef:
+                name: coldfront-postgres-ha-pguser-coldfront-postgres-ha
+                key: user
+          - name: DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: coldfront-postgres-ha-pguser-coldfront-postgres-ha
+                key: password
+        envFrom:
+        - configMapRef:
+            name: coldfront-configmap
+        - secretRef:
+            name: coldfront-secrets

--- a/k8s/overlays/staging/patches/qcluster-deployment.yaml
+++ b/k8s/overlays/staging/patches/qcluster-deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: coldfront-qcluster-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: coldfront-qcluster
+        env:
+          - name: DATABASE_HOST
+            valueFrom:
+              secretKeyRef:
+                name: coldfront-postgres-ha-pguser-coldfront-postgres-ha
+                key: host
+          - name: DATABASE_PORT
+            valueFrom:
+              secretKeyRef:
+                name: coldfront-postgres-ha-pguser-coldfront-postgres-ha
+                key: port
+          - name: DATABASE_NAME
+            valueFrom:
+              secretKeyRef:
+                name: coldfront-postgres-ha-pguser-coldfront-postgres-ha
+                key: dbname
+          - name: DATABASE_USER
+            valueFrom:
+              secretKeyRef:
+                name: coldfront-postgres-ha-pguser-coldfront-postgres-ha
+                key: user
+          - name: DATABASE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: coldfront-postgres-ha-pguser-coldfront-postgres-ha
+                key: password
+        envFrom:
+        - configMapRef:
+            name: coldfront-configmap
+        - secretRef:
+            name: coldfront-secrets

--- a/k8s/overlays/staging/secrets/coldfront.yaml
+++ b/k8s/overlays/staging/secrets/coldfront.yaml
@@ -1,0 +1,64 @@
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: coldfront-secrets
+spec:
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  target:
+    name: coldfront-secrets
+  data:
+  - secretKey: OIDC_RP_CLIENT_ID
+    remoteRef:
+      key: coldfront/oidc
+      property: OIDC_RP_CLIENT_ID
+  - secretKey: OIDC_RP_CLIENT_SECRET
+    remoteRef:
+      key: coldfront/oidc
+      property: OIDC_RP_CLIENT_SECRET
+  - secretKey: OPENSTACK_NERC_APPLICATION_CREDENTIAL_ID
+    remoteRef:
+      key: coldfront/nerc-openstack-app-creds
+      property: OPENSTACK_NERC_APPLICATION_CREDENTIAL_ID
+  - secretKey: OPENSTACK_NERC_APPLICATION_CREDENTIAL_SECRET
+    remoteRef:
+      key: coldfront/nerc-openstack-app-creds
+      property: OPENSTACK_NERC_APPLICATION_CREDENTIAL_SECRET
+  - secretKey: OPENSHIFT_NERC_USERNAME
+    remoteRef:
+      key: coldfront/nerc-openshift-acct-mgt-credentials
+      property: OPENSHIFT_NERC_USERNAME
+  - secretKey: OPENSHIFT_NERC_PASSWORD
+    remoteRef:
+      key: coldfront/nerc-openshift-acct-mgt-credentials
+      property: OPENSHIFT_NERC_PASSWORD
+  - secretKey: OPENSHIFT_NERC_EXPERIMENTAL_USERNAME
+    remoteRef:
+      key: coldfront/nerc-openshift-acct-mgt-credentials
+      property: OPENSHIFT_NERC_EXPERIMENTAL_USERNAME
+  - secretKey: OPENSHIFT_NERC_EXPERIMENTAL_PASSWORD
+    remoteRef:
+      key: coldfront/nerc-openshift-acct-mgt-credentials
+      property: OPENSHIFT_NERC_EXPERIMENTAL_PASSWORD
+  - secretKey: KEYCLOAK_USER
+    remoteRef:
+      key: coldfront/keycloak-creds
+      property: KEYCLOAK_USER
+  - secretKey: KEYCLOAK_PASS
+    remoteRef:
+      key: coldfront/keycloak-creds
+      property: KEYCLOAK_PASS
+  - secretKey: SECRET_KEY
+    remoteRef:
+      key: coldfront/django
+      property: SECRET_KEY
+  - secretKey: EMAIL_HOST_USER
+    remoteRef:
+      key: accounts/aws/mghpcc/smtp
+      property: EMAIL_HOST_USER
+  - secretKey: EMAIL_HOST_PASSWORD
+    remoteRef:
+      key: accounts/aws/mghpcc/smtp
+      property: EMAIL_HOST_PASSWORD


### PR DESCRIPTION
This sets up coldfront-staging.mss.mghpcc.org for testing new ColdFront features/deployments.

This deployment is slightly different from prod in the following ways:
- No database backups to S3-compatible storage
- Ingress updated to use coldfront-staging.mss.mghpcc.org
- OIDC callback urls updated to use coldfront-staging.mss.mghpcc.org

We will need to add coldfront-staging.mss.mghpcc.org to the list of allowed URLs in the coldfront keycloak client.