### PR TITLE
Update ColdFront version to v1.1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/ubccr/coldfront@2e60db247fd9a9b0d1299f1e98f1e4ef5f5c259b#egg=coldfront
+git+https://github.com/ubccr/coldfront@v1.1.4#egg=coldfront
 git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.2.0#egg=coldfront_plugin_cloud
 git+https://github.com/nerc-project/coldfront-plugin-keycloak@0dd8e0ae65211d2f145abfd8d1402efe96562d29#egg=coldfront_plugin_keycloak_usersearch
 mysqlclient


### PR DESCRIPTION
Note:
   Requires running database migrations since it includes new schema.

Among other things, this fixes #76, since it corrects the mismatch between our version of the email templates and coldfront code.

It also includes
- Only Denied sending a signal, now Revoked also does. https://github.com/ubccr/coldfront/issues/474

- Implements project attributes, which can be really useful. https://github.com/ubccr/coldfront/pull/466

- Updates the ColdFront logo https://github.com/ubccr/coldfront/pull/431

Closes #76