### PR TITLE
prod: use v0.2.1-alpha.1 coldfront image

### DIFF
--- a/k8s/overlays/prod/patches/coldfront-deployment.yaml
+++ b/k8s/overlays/prod/patches/coldfront-deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: coldfront
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.2.0
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.2.1-alpha.1
         env:
           - name: DATABASE_HOST
             valueFrom:

--- a/k8s/overlays/prod/patches/coldfront-static-files-deployment.yaml
+++ b/k8s/overlays/prod/patches/coldfront-static-files-deployment.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       initContainers:
       - name: coldfront-static-files-copy
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.2.0
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.2.1-alpha.1

--- a/k8s/overlays/prod/patches/qcluster-deployment.yaml
+++ b/k8s/overlays/prod/patches/qcluster-deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: coldfront-qcluster
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.2.0
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.2.1-alpha.1
         env:
           - name: DATABASE_HOST
             valueFrom:


### PR DESCRIPTION
This updates the production manifests to use the latest coldfront-nerc image with the latest OpenShift support improvements in the coldfront-plugin-cloud package. To be merged during Monday's maintenance:

https://nerc.mghpcc.org/events/nerc-coldfront-upgrade-and-maintenace-april-03-2023/