### PR TITLE
Integrate coldfront-plugin-api

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,10 @@ ENV PATH="/opt/venv/bin:$PATH"
 COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install -r /tmp/requirements.txt
 
+COPY patches/01_add_api_urls.patch /opt/venv/lib/python3.9/site-packages/
+RUN cd /opt/venv/lib/python3.9/site-packages && \
+    patch -p1 < 01_add_api_urls.patch
+
 # Final Image
 FROM python:3.9-slim-bullseye
 

--- a/patches/01_add_api_urls.patch
+++ b/patches/01_add_api_urls.patch
@@ -1,0 +1,11 @@
+diff --git a/coldfront/config/urls.py b/coldfront/config/urls.py
+index 353e360..220378a 100644
+--- a/coldfront/config/urls.py
++++ b/coldfront/config/urls.py
+@@ -36,3 +36,6 @@ if 'mozilla_django_oidc' in settings.INSTALLED_APPS:
+ 
+ if 'django_su.backends.SuBackend' in settings.AUTHENTICATION_BACKENDS:
+     urlpatterns.append(path('su/', include('django_su.urls')))
++
++if 'coldfront_plugin_api' in settings.INSTALLED_APPS:
++    urlpatterns.append(path('api/', include('coldfront_plugin_api.urls')))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 git+https://github.com/ubccr/coldfront@v1.1.4#egg=coldfront
 git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.2.1-alpha.1#egg=coldfront_plugin_cloud
 git+https://github.com/nerc-project/coldfront-plugin-keycloak@0dd8e0ae65211d2f145abfd8d1402efe96562d29#egg=coldfront_plugin_keycloak_usersearch
+git+https://github.com/CCI-MOC/coldfront-plugin-api.git@2ccc5679b9d9cd407ef939425e19929cbc0d3fd0#egg=coldfront_plugin_api
 mysqlclient
 psycopg2 >= 2.8, < 2.9
 mozilla-django-oidc

--- a/src/local_settings.py
+++ b/src/local_settings.py
@@ -7,6 +7,7 @@ from coldfront.config.env import ENV
 
 
 NERC_STD_PLUGIN_CONFIGS = [
+    'coldfront_plugin_api.config',
     'coldfront_plugin_cloud.config',
     'coldfront_plugin_keycloak_usersearch',
 ]
@@ -46,6 +47,12 @@ DATABASES = {
         'HOST': ENV.get_value('DATABASE_HOST'),
         'PORT': ENV.get_value('DATABASE_PORT', default=3306),
     },
+}
+
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'mozilla_django_oidc.contrib.drf.OIDCAuthentication',
+    ]
 }
 
 if ENV.get_value('REDIS_HOST', default=None):


### PR DESCRIPTION
- Introduces `patches/01_add_api_urls.patch` which works around https://github.com/ubccr/coldfront/issues/518 and is applied on container build.
- Introduces `/api/allocations/` which returns a list of all Resource Allocations that are active. This API requires admin permissions to query (setting the staff flag after a first failed query)

Some notes:
- To authenticate to the API as a client, you must set `openid` as a default scope for the authenticating client and associate a mapper that maps `uid` to the User property `username`. You must also set the `email` field for the client user in Keycloak.

Closes #84