### PR TITLE
 upgrade coldfront-plugin-cloud to v0.3.0

### DIFF
--- a/k8s/overlays/staging/patches/coldfront-deployment.yaml
+++ b/k8s/overlays/staging/patches/coldfront-deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: coldfront
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.2.1-alpha.1
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.0
         env:
           - name: DATABASE_HOST
             valueFrom:

--- a/k8s/overlays/staging/patches/coldfront-static-files-deployment.yaml
+++ b/k8s/overlays/staging/patches/coldfront-static-files-deployment.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       initContainers:
       - name: coldfront-static-files-copy
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.2.1-alpha.1
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.0

--- a/k8s/overlays/staging/patches/qcluster-deployment.yaml
+++ b/k8s/overlays/staging/patches/qcluster-deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: coldfront-qcluster
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.2.1-alpha.1
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.0
         env:
           - name: DATABASE_HOST
             valueFrom:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/ubccr/coldfront@v1.1.4#egg=coldfront
-git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.2.1-alpha.1#egg=coldfront_plugin_cloud
+git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.3.0#egg=coldfront_plugin_cloud
 git+https://github.com/nerc-project/coldfront-plugin-keycloak@0dd8e0ae65211d2f145abfd8d1402efe96562d29#egg=coldfront_plugin_keycloak_usersearch
 git+https://github.com/CCI-MOC/coldfront-plugin-api.git@2ccc5679b9d9cd407ef939425e19929cbc0d3fd0#egg=coldfront_plugin_api
 mysqlclient


### PR DESCRIPTION
This updates the coldfront-plugin-cloud package to the latest version v0.3.0.

Also includes manifests for deploying to staging (tag/image to be created after merge)