### PR TITLE
k8s: update prod and staging to use v0.3.1

### DIFF
--- a/k8s/overlays/prod/patches/coldfront-deployment.yaml
+++ b/k8s/overlays/prod/patches/coldfront-deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: coldfront
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.2.1-alpha.1
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.1
         env:
           - name: DATABASE_HOST
             valueFrom:

--- a/k8s/overlays/prod/patches/coldfront-static-files-deployment.yaml
+++ b/k8s/overlays/prod/patches/coldfront-static-files-deployment.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       initContainers:
       - name: coldfront-static-files-copy
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.2.1-alpha.1
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.1

--- a/k8s/overlays/prod/patches/qcluster-deployment.yaml
+++ b/k8s/overlays/prod/patches/qcluster-deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: coldfront-qcluster
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.2.1-alpha.1
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.1
         env:
           - name: DATABASE_HOST
             valueFrom:

--- a/k8s/overlays/staging/patches/coldfront-deployment.yaml
+++ b/k8s/overlays/staging/patches/coldfront-deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: coldfront
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.0
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.1
         env:
           - name: DATABASE_HOST
             valueFrom:

--- a/k8s/overlays/staging/patches/coldfront-static-files-deployment.yaml
+++ b/k8s/overlays/staging/patches/coldfront-static-files-deployment.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       initContainers:
       - name: coldfront-static-files-copy
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.0
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.1

--- a/k8s/overlays/staging/patches/qcluster-deployment.yaml
+++ b/k8s/overlays/staging/patches/qcluster-deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: coldfront-qcluster
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.0
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.1
         env:
           - name: DATABASE_HOST
             valueFrom:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 git+https://github.com/ubccr/coldfront@v1.1.4#egg=coldfront
 git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.3.0#egg=coldfront_plugin_cloud
 git+https://github.com/nerc-project/coldfront-plugin-keycloak@0dd8e0ae65211d2f145abfd8d1402efe96562d29#egg=coldfront_plugin_keycloak_usersearch
-git+https://github.com/CCI-MOC/coldfront-plugin-api.git@37b2244de69d166d936a1fddd0a46e3f4ad328e7#egg=coldfront_plugin_api
+git+https://github.com/nerc-project/coldfront-plugin-api.git@37b2244de69d166d936a1fddd0a46e3f4ad328e7#egg=coldfront_plugin_api
 mysqlclient
 psycopg2 >= 2.8, < 2.9
 mozilla-django-oidc


### PR DESCRIPTION
Also includes a minor URL change to the `coldfront-plugin-api` due to moving the repo from CCI-MOC to nerc-project org.