### PR TITLE
clear static storage and disable prompts for input

### DIFF
--- a/k8s/base/static-files/deployment.yaml
+++ b/k8s/base/static-files/deployment.yaml
@@ -14,7 +14,7 @@ spec:
       - name: coldfront-static-files-copy
         image: 'ghcr.io/nerc-project/coldfront-nerc:main'
         imagePullPolicy: Always
-        command: ["/bin/sh", "-c", "STATIC_ROOT=/webroot/static /opt/venv/bin/django-admin.py collectstatic"]
+        command: ["/bin/sh", "-c", "STATIC_ROOT=/webroot/static /opt/venv/bin/django-admin.py collectstatic --no-input --clear"]
         env:
           - name: DATABASE_HOST
             value: ''


### PR DESCRIPTION
The init container in for the static files deployment calls collectstatic which is now prompting for user input. This adds two additional options to disable prompting for user input and also clearing out any previous files on the storage before copying the static files to the web root location.