### PR TITLE
upgrade coldfront to v1.1.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,11 @@ FROM python:3.9-slim-bullseye as builder
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential default-libmysqlclient-dev libpq-dev git && \
+        build-essential \
+        default-libmysqlclient-dev \
+        libpq-dev \
+        git \
+        pkg-config && \
     apt-get clean -y
 
 RUN python3 -m venv /opt/venv

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-git+https://github.com/ubccr/coldfront@v1.1.4#egg=coldfront
+git+https://github.com/ubccr/coldfront@v1.1.5#egg=coldfront
 git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.3.0#egg=coldfront_plugin_cloud
 git+https://github.com/nerc-project/coldfront-plugin-keycloak@0dd8e0ae65211d2f145abfd8d1402efe96562d29#egg=coldfront_plugin_keycloak_usersearch
 git+https://github.com/nerc-project/coldfront-plugin-api.git@0680de972f36df8cbd37d181a4ca68337a6918f1#egg=coldfront_plugin_api


### PR DESCRIPTION
This is a security fix release:

https://github.com/ubccr/coldfront/releases/tag/v1.1.5