### PR TITLE
k8s: bump prod to v0.3.3

### DIFF
--- a/k8s/overlays/prod/patches/coldfront-deployment.yaml
+++ b/k8s/overlays/prod/patches/coldfront-deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: coldfront
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.2
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.3
         env:
           - name: DATABASE_HOST
             valueFrom:

--- a/k8s/overlays/prod/patches/coldfront-static-files-deployment.yaml
+++ b/k8s/overlays/prod/patches/coldfront-static-files-deployment.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       initContainers:
       - name: coldfront-static-files-copy
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.2
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.3

--- a/k8s/overlays/prod/patches/qcluster-deployment.yaml
+++ b/k8s/overlays/prod/patches/qcluster-deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: coldfront-qcluster
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.2
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.3
         env:
           - name: DATABASE_HOST
             valueFrom:


### PR DESCRIPTION
To pull in latest coldfront v1.1.5 (security fix release)