### PR TITLE
fix email templates for coldfront v1.1.5

### DIFF
--- a/src/email/allocation_activated.txt
+++ b/src/email/allocation_activated.txt
@@ -2,7 +2,7 @@ Dear {{center_name}} user,
 
 Your allocation request for {{resource}} has been activated. You now have access to this resource.
 
-To view your allocations information, please go to {{allocation_url}}
+To view your allocations information, please go to {{url}}
 
 Thank you,
 {{signature}}

--- a/src/email/allocation_change_approved.txt
+++ b/src/email/allocation_change_approved.txt
@@ -2,7 +2,7 @@ Dear {{center_name}} user,
 
 Your allocation change request for {{resource}} has been approved. The requested changes are now active.
 
-To view your allocation's information, please go to {{allocation_url}}
+To view your allocation's information, please go to {{url}}
 
 Thank you,
 {{signature}}

--- a/src/email/allocation_change_denied.txt
+++ b/src/email/allocation_change_denied.txt
@@ -2,7 +2,7 @@ Dear {{center_name}} user,
 
 Your allocation change request for {{resource}} has been denied.
 
-Please login to view a message from the system administrators pertaining to your allocation change request: {{allocation_url}}
+Please login to view a message from the system administrators pertaining to your allocation change request: {{url}}
 
 Thank you,
 {{signature}}

--- a/src/email/allocation_denied.txt
+++ b/src/email/allocation_denied.txt
@@ -2,7 +2,7 @@ Dear {{center_name}} user,
 
 Your allocation request for {{resource}} has been denied.
 
-Please login to view a message from the system administrators: {{allocation_url}}
+Please login to view a message from the system administrators: {{url}}
 
 Thank you,
 {{signature}}


### PR DESCRIPTION
In coldfront v1.1.5, the `{{allocation_url}}` template parameter got renamed to just `{{url}}`