### PR TITLE
k8s: use latest coldfront-nerc v0.3.5 image

### DIFF
--- a/k8s/overlays/prod/patches/coldfront-deployment.yaml
+++ b/k8s/overlays/prod/patches/coldfront-deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: coldfront
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.4
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.5
         env:
           - name: DATABASE_HOST
             valueFrom:

--- a/k8s/overlays/prod/patches/coldfront-static-files-deployment.yaml
+++ b/k8s/overlays/prod/patches/coldfront-static-files-deployment.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       initContainers:
       - name: coldfront-static-files-copy
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.4
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.5

--- a/k8s/overlays/prod/patches/qcluster-deployment.yaml
+++ b/k8s/overlays/prod/patches/qcluster-deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: coldfront-qcluster
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.4
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.5
         env:
           - name: DATABASE_HOST
             valueFrom:

--- a/k8s/overlays/staging/patches/coldfront-deployment.yaml
+++ b/k8s/overlays/staging/patches/coldfront-deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: coldfront
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.4
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.5
         env:
           - name: DATABASE_HOST
             valueFrom:

--- a/k8s/overlays/staging/patches/coldfront-static-files-deployment.yaml
+++ b/k8s/overlays/staging/patches/coldfront-static-files-deployment.yaml
@@ -7,4 +7,4 @@ spec:
     spec:
       initContainers:
       - name: coldfront-static-files-copy
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.4
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.5

--- a/k8s/overlays/staging/patches/qcluster-deployment.yaml
+++ b/k8s/overlays/staging/patches/qcluster-deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: coldfront-qcluster
-        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.4
+        image: ghcr.io/nerc-project/coldfront-nerc:v0.3.5
         env:
           - name: DATABASE_HOST
             valueFrom:


### PR DESCRIPTION
Deployed both to staging and prod.