### PR TITLE
postgres: use local registry crunchydata images

### DIFF
--- a/k8s/overlays/prod/ha-postgres.yaml
+++ b/k8s/overlays/prod/ha-postgres.yaml
@@ -3,7 +3,7 @@ kind: PostgresCluster
 metadata:
   name: coldfront-postgres-ha
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.4-1
+  image: default-route-openshift-image-registry.apps.nerc-shift-1.rc.fas.harvard.edu/postgres-operator/crunchy-postgres:latest
   postgresVersion: 13
   instances:
     - name: pgha1
@@ -26,7 +26,7 @@ spec:
                   postgres-operator.crunchydata.com/instance-set: pgha1
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.35-0
+      image: default-route-openshift-image-registry.apps.nerc-shift-1.rc.fas.harvard.edu/postgres-operator/crunchy-pgbackrest:latest
       configuration:
       - secret:
           name: pgo-s3-conf
@@ -65,7 +65,7 @@ spec:
           region: "us-east-1"
   proxy:
     pgBouncer:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-3
+      image: default-route-openshift-image-registry.apps.nerc-shift-1.rc.fas.harvard.edu/postgres-operator/crunchy-pgbouncer:latest
       replicas: 2
       affinity:
         podAntiAffinity:

--- a/k8s/overlays/staging/ha-postgres.yaml
+++ b/k8s/overlays/staging/ha-postgres.yaml
@@ -3,7 +3,7 @@ kind: PostgresCluster
 metadata:
   name: coldfront-postgres-ha
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.4-1
+  image: default-route-openshift-image-registry.apps.nerc-shift-1.rc.fas.harvard.edu/postgres-operator/crunchy-postgres:latest
   postgresVersion: 13
   instances:
     - name: pgha1
@@ -26,7 +26,7 @@ spec:
                   postgres-operator.crunchydata.com/instance-set: pgha1
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.35-0
+      image: default-route-openshift-image-registry.apps.nerc-shift-1.rc.fas.harvard.edu/postgres-operator/crunchy-pgbackrest:latest
       repos:
       - name: repo1
         volume:
@@ -38,7 +38,7 @@ spec:
                 storage: 5Gi
   proxy:
     pgBouncer:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-3
+      image: default-route-openshift-image-registry.apps.nerc-shift-1.rc.fas.harvard.edu/postgres-operator/crunchy-pgbouncer:latest
       replicas: 2
       affinity:
         podAntiAffinity:


### PR DESCRIPTION
The images upstream are subject to be deprecated and removed. Switch to using the copies of these images stored in the local image registry (see: https://github.com/nerc-project/nerc-k8s-operators/pull/45)