### PR TITLE
release v0.3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,10 @@ COPY requirements.txt /tmp/requirements.txt
 RUN pip3 install -r /tmp/requirements.txt
 
 COPY patches/01_add_api_urls.patch /opt/venv/lib/python3.9/site-packages/
+COPY patches/02_fix_allocation_denied_revoked_PR596.patch /opt/venv/lib/python3.9/site-packages/
 RUN cd /opt/venv/lib/python3.9/site-packages && \
-    patch -p1 < 01_add_api_urls.patch
+    patch -p1 < 01_add_api_urls.patch && \
+    patch -p1 < 02_fix_allocation_denied_revoked_PR596.patch
 
 # Final Image
 FROM python:3.9-slim-bullseye

--- a/patches/02_fix_allocation_denied_revoked_PR596.patch
+++ b/patches/02_fix_allocation_denied_revoked_PR596.patch
@@ -1,0 +1,14 @@
+diff --git a/coldfront/core/allocation/views.py b/coldfront/core/allocation/views.py
+index 216c3531c..ec129fc39 100644
+--- a/coldfront/core/allocation/views.py
++++ b/coldfront/core/allocation/views.py
+@@ -238,7 +238,7 @@ def post(self, request, *args, **kwargs):
+             allocation_obj.end_date = None
+             allocation_obj.save()
+
+-            if allocation_obj.status.name == ['Denied', 'Revoked']:
++            if allocation_obj.status.name in ['Denied', 'Revoked']:
+                 allocation_disable.send(
+                     sender=self.__class__, allocation_pk=allocation_obj.pk)
+                 allocation_users = allocation_obj.allocationuser_set.exclude(
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 git+https://github.com/ubccr/coldfront@v1.1.5#egg=coldfront
-git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.4.1#egg=coldfront_plugin_cloud
-git+https://github.com/nerc-project/coldfront-plugin-keycloak@0dd8e0ae65211d2f145abfd8d1402efe96562d29#egg=coldfront_plugin_keycloak_usersearch
-git+https://github.com/nerc-project/coldfront-plugin-api.git@f0bfbd9d5e6707eb8bb7297b782502012d2b1266#egg=coldfront_plugin_api
+git+https://github.com/nerc-project/coldfront-plugin-cloud@1fff22e096c3440bb783f1152a985f14eeef47b9#egg=coldfront_plugin_cloud
+git+https://github.com/nerc-project/coldfront-plugin-keycloak@d5f02df7bef5b4ab787d3ebb21cd11f3c133138f#egg=coldfront_plugin_keycloak_usersearch
+git+https://github.com/nerc-project/coldfront-plugin-api.git@e3e4741239671b7ab0c3c01bab28f134845cd000#egg=coldfront_plugin_api
 mysqlclient
 psycopg2 >= 2.8, < 2.9
 mozilla-django-oidc


### PR DESCRIPTION
Include latest versions of api, keycloak, and cloud plugins. Includes a coldfront patch that has yet to be merged upstream to fix a bug that prevented allocations from being disabled even after it has been denied or revoked:

https://github.com/ubccr/coldfront/pull/596