### PR TITLE
Update `coldfront-plugin-cloud` to 0.5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/ubccr/coldfront@v1.1.5#egg=coldfront
-git+https://github.com/nerc-project/coldfront-plugin-cloud@1fff22e096c3440bb783f1152a985f14eeef47b9#egg=coldfront_plugin_cloud
+git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.5.0#egg=coldfront_plugin_cloud
 git+https://github.com/nerc-project/coldfront-plugin-keycloak@d5f02df7bef5b4ab787d3ebb21cd11f3c133138f#egg=coldfront_plugin_keycloak_usersearch
 git+https://github.com/nerc-project/coldfront-plugin-api.git@e3e4741239671b7ab0c3c01bab28f134845cd000#egg=coldfront_plugin_api
 mysqlclient


### PR DESCRIPTION
See comparison with new commits at
https://github.com/nerc-project/coldfront-plugin-cloud/compare/1fff22e096c3440bb783f1152a985f14eeef47b9...v.0.5.0

Mostly invoicing changes which can now upload to s3 automatically.

Also adds a command to migrate fields of science.