### PR TITLE
Update `coldfront-plugin-api` to v0.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 git+https://github.com/ubccr/coldfront@v1.1.5#egg=coldfront
 git+https://github.com/nerc-project/coldfront-plugin-cloud@1fff22e096c3440bb783f1152a985f14eeef47b9#egg=coldfront_plugin_cloud
 git+https://github.com/nerc-project/coldfront-plugin-keycloak@d5f02df7bef5b4ab787d3ebb21cd11f3c133138f#egg=coldfront_plugin_keycloak_usersearch
-git+https://github.com/nerc-project/coldfront-plugin-api.git@e3e4741239671b7ab0c3c01bab28f134845cd000#egg=coldfront_plugin_api
+git+https://github.com/nerc-project/coldfront-plugin-api.git@v0.2.0#egg=coldfront_plugin_api
 mysqlclient
 psycopg2 >= 2.8, < 2.9
 mozilla-django-oidc


### PR DESCRIPTION
https://github.com/nerc-project/coldfront-plugin-api/compare/e3e4741239671b7ab0c3c01bab28f134845cd000...v0.2.0

- Fixes an error with the users API from the introduction of django_scim2
- Moves the group to use django_scim2 too
- Introduces filtering to the allocations API