### PR TITLE
bump coldfront-plugin-cloud to 0.5.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/ubccr/coldfront@v1.1.5#egg=coldfront
-git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.5.2#egg=coldfront_plugin_cloud
+git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.5.3#egg=coldfront_plugin_cloud
 git+https://github.com/nerc-project/coldfront-plugin-keycloak@d5f02df7bef5b4ab787d3ebb21cd11f3c133138f#egg=coldfront_plugin_keycloak_usersearch
 git+https://github.com/nerc-project/coldfront-plugin-api.git@v0.2.0#egg=coldfront_plugin_api
 mysqlclient


### PR DESCRIPTION
This pulls in a minor patch to fix the object store quota value comparison in v0.5.2:

https://github.com/nerc-project/coldfront-plugin-cloud/pull/160