### PR TITLE
Added new allocation status "Active (Needs Renewal)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,12 @@ RUN pip3 install -r /tmp/requirements.txt
 
 COPY patches/01_add_api_urls.patch /opt/venv/lib/python3.9/site-packages/
 COPY patches/02_fix_allocation_denied_revoked_PR596.patch /opt/venv/lib/python3.9/site-packages/
+COPY patches/03_add_active_needs_renewal_status.patch /opt/venv/lib/python3.9/site-packages/
+
 RUN cd /opt/venv/lib/python3.9/site-packages && \
     patch -p1 < 01_add_api_urls.patch && \
-    patch -p1 < 02_fix_allocation_denied_revoked_PR596.patch
+    patch -p1 < 02_fix_allocation_denied_revoked_PR596.patch && \
+    patch -p1 < 03_add_active_needs_renewal_status.patch
 
 # Final Image
 FROM python:3.9-slim-bullseye

--- a/patches/03_add_active_needs_renewal_status.patch
+++ b/patches/03_add_active_needs_renewal_status.patch
@@ -1,0 +1,26 @@
+diff --git a/coldfront/core/allocation/management/commands/add_allocation_defaults.py b/coldfront/core/allocation/management/commands/add_allocation_defaults.py
+index ca5c4fc..556eeb2 100644
+--- a/coldfront/core/allocation/management/commands/add_allocation_defaults.py
++++ b/coldfront/core/allocation/management/commands/add_allocation_defaults.py
+@@ -16,7 +16,7 @@ class Command(BaseCommand):
+             'Attribute Expanded Text'):
+             AttributeType.objects.get_or_create(name=attribute_type)
+ 
+-        for choice in ('Active', 'Denied', 'Expired',
++        for choice in ('Active (Needs Renewal)', 'Active', 'Denied', 'Expired',
+                        'New', 'Paid', 'Payment Pending',
+                        'Payment Requested', 'Payment Declined',
+                        'Renewal Requested', 'Revoked', 'Unpaid',):
+diff --git a/coldfront/core/allocation/tasks.py b/coldfront/core/allocation/tasks.py
+index e1a37fc..ba96800 100644
+--- a/coldfront/core/allocation/tasks.py
++++ b/coldfront/core/allocation/tasks.py
+@@ -29,7 +29,7 @@ EMAIL_ADMIN_LIST = import_from_settings('EMAIL_ADMIN_LIST')
+ def update_statuses():
+ 
+     expired_status_choice = AllocationStatusChoice.objects.get(
+-        name='Expired')
++        name='Active (Needs Renewal)')
+     allocations_to_expire = Allocation.objects.filter(
+         status__name__in=['Active','Payment Pending','Payment Requested', 'Unpaid',], end_date__lt=datetime.datetime.now().date())
+     for sub_obj in allocations_to_expire:


### PR DESCRIPTION
Closes #120. When any Coldfront expires, the allocation's status will change to "Active (Needs Renewal)" instead of "Expired"