### PR TITLE
nerc-shift-1: bump pgha storage to 8Gi

### DIFF
--- a/k8s/overlays/prod/ha-postgres.yaml
+++ b/k8s/overlays/prod/ha-postgres.yaml
@@ -13,7 +13,7 @@ spec:
         - "ReadWriteOnce"
         resources:
           requests:
-            storage: 5Gi
+            storage: 8Gi
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
The pgha data volumes filled up - bumping to 8Gi for now.