### PR TITLE
Update pins for Feb 11 upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 git+https://github.com/ubccr/coldfront@v1.1.5#egg=coldfront
-git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.5.5#egg=coldfront_plugin_cloud
+git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.7.0#egg=coldfront_plugin_cloud
 git+https://github.com/nerc-project/coldfront-plugin-keycloak@d5f02df7bef5b4ab787d3ebb21cd11f3c133138f#egg=coldfront_plugin_keycloak_usersearch
-git+https://github.com/nerc-project/coldfront-plugin-api.git@v0.2.0#egg=coldfront_plugin_api
+git+https://github.com/nerc-project/coldfront-plugin-api.git@v0.2.1#egg=coldfront_plugin_api
 mysqlclient
 psycopg2 >= 2.8, < 2.9
 mozilla-django-oidc


### PR DESCRIPTION

- ColdFront API is updated to 0.2.1 from 0.2.0, which fixes an authentication bug in the SCIM API. https://github.com/nerc-project/coldfront-plugin-api/releases/tag/v0.2.1
- ColdFront Cloud Plugin from 0.5.5 to 0.7.0, which introduces support for ESI and support for outage hours in generating invoices. https://github.com/nerc-project/coldfront-plugin-cloud/releases