### PR TITLE
Updated version pin for coldfront cloud and api plugins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 git+https://github.com/ubccr/coldfront@v1.1.5#egg=coldfront
-git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.7.0#egg=coldfront_plugin_cloud
+git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.8.0#egg=coldfront_plugin_cloud
 git+https://github.com/nerc-project/coldfront-plugin-keycloak@d5f02df7bef5b4ab787d3ebb21cd11f3c133138f#egg=coldfront_plugin_keycloak_usersearch
-git+https://github.com/nerc-project/coldfront-plugin-api.git@v0.2.1#egg=coldfront_plugin_api
+git+https://github.com/nerc-project/coldfront-plugin-api.git@v0.2.2#egg=coldfront_plugin_api
 mysqlclient
 psycopg2 >= 2.8, < 2.9
 mozilla-django-oidc


### PR DESCRIPTION
Closes #140. Besides the version pin update, a few instructions below:

With this latest update, a few breaking changes have been added to the coldfront cloud plugin. The following things should be done for the plugin to work properly.

- `register_cloud_attributes` needs to be run to add new resource and allocation attributes, as well as the new Openshift VM resource class
- After `register_cloud_attributes `, a new resource attribute, `OpenShift API Endpoint URL`, will become available and will need to be added to all existing Openshift resources. This should be the URL to the Openshift API linked to the resource, and is distinct from the URL to the account manager. This is necessary since the coldfront cloud plugin will now directly communicate with the Openshift API.
- For Coldfront to authenticate to each Openshift cluster’s API, an environment variable in the format of `OPENSHIFT_{resource_name}_TOKEN` must be set, where `resource_name` is the name of the Openshift resource, to uppercase, with “ “ and “-“ replaced with “_”. The variable’s value should be the access token of an Openshift service account with appropriate permissions and expiration date. 
- Lastly, run `validate_allocations --apply` to add  the label `nerc.mghpcc.org/allow-unencrypted-routes: 'true'` to pre-existing Openshift allocations.