### PR TITLE
bump coldfront to v1.1.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-git+https://github.com/ubccr/coldfront@v1.1.5#egg=coldfront
-git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.8.0#egg=coldfront_plugin_cloud
+git+https://github.com/ubccr/coldfront@v1.1.6#egg=coldfront
+git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.8.1#egg=coldfront_plugin_cloud
 git+https://github.com/nerc-project/coldfront-plugin-keycloak@d5f02df7bef5b4ab787d3ebb21cd11f3c133138f#egg=coldfront_plugin_keycloak_usersearch
 git+https://github.com/nerc-project/coldfront-plugin-api.git@v0.2.2#egg=coldfront_plugin_api
 mysqlclient


### PR DESCRIPTION
This pulls in newer django which is required for SMTP to work with python3.12.

Currently with v1.1.5 and python3.12 we're getting the following stacktrace when coldfront/django attempts to send email:
```
 TypeError: SMTP.starttls() got an unexpected keyword argument 'keyfile'
 ```

This is due to deprecations in python 3.12