### PR TITLE
Removed credentials for Openshift account manager

### DIFF
--- a/k8s/overlays/prod/secrets/coldfront.yaml
+++ b/k8s/overlays/prod/secrets/coldfront.yaml
@@ -26,14 +26,6 @@ spec:
     remoteRef:
       key: coldfront/nerc-openstack-app-creds
       property: OPENSTACK_NERC_APPLICATION_CREDENTIAL_SECRET
-  - secretKey: OPENSHIFT_NERC_OCP_USERNAME
-    remoteRef:
-      key: coldfront/nerc-openshift-acct-mgt-credentials
-      property: OPENSHIFT_NERC_USERNAME
-  - secretKey: OPENSHIFT_NERC_OCP_PASSWORD
-    remoteRef:
-      key: coldfront/nerc-openshift-acct-mgt-credentials
-      property: OPENSHIFT_NERC_PASSWORD
   - secretKey: OPENSHIFT_NERC_OCP_TOKEN
     remoteRef:
       key: coldfront/nerc-openshift-admin-service-account


### PR DESCRIPTION
Coldfront now communicates directly with the Openshift API