### PR TITLE
fix secret name for NERC-OCP-EDU resource

### DIFF
--- a/k8s/overlays/prod/secrets/coldfront.yaml
+++ b/k8s/overlays/prod/secrets/coldfront.yaml
@@ -38,10 +38,10 @@ spec:
     remoteRef:
       key: coldfront/nerc-openshift-admin-service-account
       property: OPENSHIFT_NERC_OCP_TOKEN
-  - secretKey: OPENSHIFT_NERC_OCP_ACADEMIC_TOKEN
+  - secretKey: OPENSHIFT_NERC_OCP_EDU_TOKEN
     remoteRef:
       key: coldfront/nerc-openshift-admin-service-account
-      property: OPENSHIFT_NERC_OCP_ACADEMIC_TOKEN
+      property: OPENSHIFT_NERC_OCP_EDU_TOKEN
   - secretKey: KEYCLOAK_USER
     remoteRef:
       key: coldfront/keycloak-creds

--- a/k8s/overlays/staging/secrets/coldfront.yaml
+++ b/k8s/overlays/staging/secrets/coldfront.yaml
@@ -38,10 +38,10 @@ spec:
     remoteRef:
       key: coldfront/nerc-openshift-admin-service-account
       property: OPENSHIFT_NERC_OCP_TOKEN
-  - secretKey: OPENSHIFT_NERC_OCP_ACADEMIC_TOKEN
+  - secretKey: OPENSHIFT_NERC_OCP_EDU_TOKEN
     remoteRef:
       key: coldfront/nerc-openshift-admin-service-account
-      property: OPENSHIFT_NERC_OCP_ACADEMIC_TOKEN
+      property: OPENSHIFT_NERC_OCP_EDU_TOKEN
   - secretKey: KEYCLOAK_USER
     remoteRef:
       key: coldfront/keycloak-creds


### PR DESCRIPTION
We ended up naming the resource NERC-OCP-EDU instead of NERC-OCP-ACADEMIC.