### PR TITLE
Bump `coldfront-plugin-cloud` version to 0.9.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/ubccr/coldfront@v1.1.6#egg=coldfront
-git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.9.1#egg=coldfront_plugin_cloud
+git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.9.3#egg=coldfront_plugin_cloud
 git+https://github.com/nerc-project/coldfront-plugin-keycloak@d5f02df7bef5b4ab787d3ebb21cd11f3c133138f#egg=coldfront_plugin_keycloak_usersearch
 git+https://github.com/nerc-project/coldfront-plugin-api.git@v0.2.2#egg=coldfront_plugin_api
 mysqlclient


### PR DESCRIPTION
As part of this update, we will reduce [the minimum resource request for Openshift allocations](https://github.com/nerc-project/coldfront-plugin-cloud/pull/241). After this PR is merged, the following migrations steps would be:
- A new test Openshift allocation should be created
- Inspect the project on Openshift and check that the limit range minimums for this new allocation is the correct values