### PR TITLE
Bump coldfront-plugin-cloud to v0.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/ubccr/coldfront@v1.1.6#egg=coldfront
-git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.9.3#egg=coldfront_plugin_cloud
+git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.10.0#egg=coldfront_plugin_cloud
 git+https://github.com/nerc-project/coldfront-plugin-keycloak@d5f02df7bef5b4ab787d3ebb21cd11f3c133138f#egg=coldfront_plugin_keycloak_usersearch
 git+https://github.com/nerc-project/coldfront-plugin-api.git@v0.2.2#egg=coldfront_plugin_api
 mysqlclient


### PR DESCRIPTION
As part of this update, we plan to mark certain clusters as having IBM Scale Storage available, and to add an allocation attribute on all Openshift allocations to indicate their IBM Storage quota. Additionally, allocations with the `Active (Needs Renewal)` status will be validated by `validate_allocations`. Some additional minor fixes to the `validate_allocations` command.

The migrations steps would be:
- Run `register_cloud_attributes`. This will add the new IBM Scale attributes, as well as migrate the old OpenShift Request on Storage Quota (GiB) storage attribute to OpenShift Request on NESE Storage Quota (GiB)
- Check Openshift allocations on Coldfront to make sure migration is complete
- Add the resource attribute `IBM Spectrum Scale Storage Available` to all Openshift resources that have IBM Storage available on it, and set to `true`
- Run `validate_allocations` without the `--apply` argument. Given the new changes, several things may happen:
  - If an Openshift allocation doesn't have a quota attribute set on either Coldfront or on the cluster, the message `Value for quota for {attr} is not set anywhere` will appear. `--apply` will have the default value for the quota set on both Coldfront and the cluster
  - There may be validation warnings for allocations with the status `Active (Needs Renewal)`
- Run `validate_allocations` with `--apply` after reviewing all logged warnings
- Confirm Openshift projects now have a quota for `ocs-external-storagecluster-ceph-rbd.storageclass.storage.k8s.io/requests.storage` instead of `requests.storage`. 