### PR TITLE
staging: set MOKEY_OIDC_PI_GROUP to pi

### DIFF
--- a/k8s/overlays/staging/configmap.yaml
+++ b/k8s/overlays/staging/configmap.yaml
@@ -9,6 +9,7 @@ data:
   OPENSTACK_DEVSTACK_APPLICATION_CREDENTIAL_SECRET: ""
   PLUGIN_AUTH_OIDC: "True"
   PLUGIN_MOKEY: "True"
+  MOKEY_OIDC_PI_GROUP: "pi"
   OIDC_RP_SIGN_ALGO: RS256
   OIDC_RP_SCOPES: "openid email profile"
   OIDC_OP_AUTHORIZATION_ENDPOINT: "https://keycloak.mss.mghpcc.org/auth/realms/mss/protocol/openid-connect/auth"


### PR DESCRIPTION
This appears to be strictly required now - likely a bug - in v1.1.7.

It defaults to "pi" according to:

https://github.com/ubccr/coldfront/blob/9aa84ceb6480fc1a6b1354ff30212dfd96e60fff/coldfront/plugins/mokey_oidc/auth.py#L14

Setting it to "pi" explicitly for now.