### PR TITLE
Update coldfront-plugin-cloud pin for 04/2026 maintenance

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/ubccr/coldfront@v1.1.7#egg=coldfront
-git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.12.2#egg=coldfront_plugin_cloud
+git+https://github.com/nerc-project/coldfront-plugin-cloud@v0.13.0#egg=coldfront_plugin_cloud
 git+https://github.com/nerc-project/coldfront-plugin-keycloak@d5f02df7bef5b4ab787d3ebb21cd11f3c133138f#egg=coldfront_plugin_keycloak_usersearch
 git+https://github.com/nerc-project/coldfront-plugin-api.git@v0.2.3#egg=coldfront_plugin_api
 mysqlclient


### PR DESCRIPTION
For this Coldfront update, we do not expect there to be any functional changes to how `coldfront-plugin-cloud` behaves. All the PRs only involve refactoring, most significantly with the `validate_allocations` command. Therefore, migration steps are fairly simple:
- Check that `Allocation_Cumulative_Charges` allocation attribute is no longer private or changeable
- Create test `Openshift` and `Openstack` allocations to test `validate_allocations`
- Check the command can handle different scenarios, i.e when the quota is missing/unequal on either the Coldfront or cluster side